### PR TITLE
Remove plugins from `env`, `processor`, and `overrides` as well

### DIFF
--- a/src/eslintDisable.ts
+++ b/src/eslintDisable.ts
@@ -33,7 +33,7 @@ const disablePlugins = (eslintConfig: any, pluginNames: string[]) => {
 
     for (const [key] of Object.entries(nextEslintConfig.env)) {
       if (key.startsWith(pluginName + '/')) {
-        delete nextEslintConfig.rules[key];
+        delete nextEslintConfig.env[key];
       }
     }
   }

--- a/src/eslintDisable.ts
+++ b/src/eslintDisable.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-dynamic-delete */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable fp/no-delete */
@@ -20,30 +19,36 @@ const extractConfig = (baseConfig: any) => {
 const disablePlugins = (eslintConfig: any, pluginNames: string[]) => {
   const nextEslintConfig = clone(eslintConfig);
 
-  nextEslintConfig.plugins = nextEslintConfig.plugins.filter((pluginName) => {
-    return !pluginNames.includes(pluginName);
-  });
+  if (nextEslintConfig.plugins) {
+    nextEslintConfig.plugins = nextEslintConfig.plugins.filter((pluginName) => {
+      return !pluginNames.includes(pluginName);
+    });
+  }
 
   for (const pluginName of pluginNames) {
-    for (const [key] of Object.entries(nextEslintConfig.rules)) {
+    for (const [key] of Object.entries(nextEslintConfig.rules || {})) {
       if (key.startsWith(pluginName + '/')) {
         delete nextEslintConfig.rules[key];
       }
     }
 
-    for (const [key] of Object.entries(nextEslintConfig.env)) {
+    for (const [key] of Object.entries(nextEslintConfig.env || {})) {
       if (key.startsWith(pluginName + '/')) {
         delete nextEslintConfig.env[key];
       }
     }
+
+    if (nextEslintConfig.processor?.startsWith(pluginName + '/')) {
+      delete nextEslintConfig.processor;
+    }
   }
 
-  if (nextEslintConfig.processor && nextEslintConfig.processor.startsWith(pluginName + '/')) {
-    delete nextEslintConfig.processor;
+  if (nextEslintConfig.overrides) {
+    nextEslintConfig.overrides = nextEslintConfig.overrides.map((override) => {
+      return disablePlugins(override, pluginNames);
+    });
   }
-  
-  nextEslintConfig.overrides = nextEslintConfig.overrides.map(override => disablePlugins(override, pluginNames))
-  
+
   return nextEslintConfig;
 };
 

--- a/src/eslintDisable.ts
+++ b/src/eslintDisable.ts
@@ -30,8 +30,20 @@ const disablePlugins = (eslintConfig: any, pluginNames: string[]) => {
         delete nextEslintConfig.rules[key];
       }
     }
+
+    for (const [key] of Object.entries(nextEslintConfig.env)) {
+      if (key.startsWith(pluginName + '/')) {
+        delete nextEslintConfig.rules[key];
+      }
+    }
   }
 
+  if (nextEslintConfig.processor && nextEslintConfig.processor.startsWith(pluginName + '/')) {
+    delete nextEslintConfig.processor;
+  }
+  
+  nextEslintConfig.overrides = nextEslintConfig.overrides.map(override => disablePlugins(override, pluginNames))
+  
   return nextEslintConfig;
 };
 

--- a/test/eslint-disable/disablePlugin.ts
+++ b/test/eslint-disable/disablePlugin.ts
@@ -9,16 +9,40 @@ test('extracts config', (t) => {
       plugins: [
         'bar',
       ],
+      env: {
+        "bar/foobar": true,
+        "es6": true,
+      },
       rules: {
         'bar/baz': 1,
         foo: 1,
       },
+      overrides: [{
+        files: ["*.js"],
+        rules: {
+          sample: 2
+        },       
+        env: {
+          "bar/foobar": false,
+        },
+        processor: "bar/process",
+      }]
     }, ['bar']),
     {
       plugins: [],
+      env: {
+        "es6": true,
+      },
       rules: {
         foo: 1,
       },
+      overrides: [{
+        files: ["*.js"],
+        rules: {
+          sample: 2
+        },       
+        env: {}
+      }]
     },
   );
 });

--- a/test/eslint-disable/disablePlugin.ts
+++ b/test/eslint-disable/disablePlugin.ts
@@ -3,46 +3,54 @@ import {
   disablePlugins,
 } from '../../src/eslintDisable';
 
-test('extracts config', (t) => {
+test('removes plugin', (t) => {
   t.deepEqual(
-    disablePlugins({
-      plugins: [
-        'bar',
-      ],
-      env: {
-        "bar/foobar": true,
-        "es6": true,
-      },
-      rules: {
-        'bar/baz': 1,
-        foo: 1,
-      },
-      overrides: [{
-        files: ["*.js"],
-        rules: {
-          sample: 2
-        },       
+    disablePlugins(
+      {
         env: {
-          "bar/foobar": false,
+          'bar/foobar': true,
+          es6: true,
         },
-        processor: "bar/process",
-      }]
-    }, ['bar']),
-    {
-      plugins: [],
-      env: {
-        "es6": true,
+        overrides: [
+          {
+            env: {
+              'bar/foobar': false,
+            },
+            files: ['*.js'],
+            processor: 'bar/process',
+            rules: {
+              sample: 2,
+            },
+          },
+        ],
+        plugins: ['bar'],
+        rules: {
+          'bar/baz': 1,
+          foo: 1,
+        },
       },
+      ['bar'],
+    ),
+    {
+      env: {
+        es6: true,
+      },
+      overrides: [
+        {
+          env: {},
+          files: ['*.js'],
+          rules: {
+            sample: 2,
+          },
+        },
+      ],
+      plugins: [],
       rules: {
         foo: 1,
       },
-      overrides: [{
-        files: ["*.js"],
-        rules: {
-          sample: 2
-        },       
-        env: {}
-      }]
     },
   );
+});
+test('empty arrays aren\'t added to empty configs', (t) => {
+  t.deepEqual(disablePlugins({}, ['bar']), {});
 });


### PR DESCRIPTION
This plugin does not remove plugins from `env`, `processor`, and `overrides`. This PR fixes that behavior. 